### PR TITLE
Build pypi packages on bullseye

### DIFF
--- a/pypi-build/Dockerfile
+++ b/pypi-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid
+FROM debian:bullseye
 
 RUN apt-get update && \
     apt-get install -y debhelper dh-python python3-all-dev python3-pip sudo && \


### PR DESCRIPTION
This needs to be merged into master so that the pypi build workflow can use it.