### PR TITLE
Fix build of amd64 packages

### DIFF
--- a/.github/workflows/armv7-contamination-deb-mirror.yml
+++ b/.github/workflows/armv7-contamination-deb-mirror.yml
@@ -52,7 +52,7 @@ jobs:
           wget ${{ env.POOL_URL }}/${{ matrix.package }}_${{ env.QT5_DEB_VERSION }}.orig.tar.xz
 
       - uses: pi-top/ghaction-packagecloud@main
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           repository: ${{ env.PACKAGECLOUD_REPO }}/${{ env.OS }}/${{ env.DISTRO }}
           files: ./*.${{ matrix.type }}

--- a/.github/workflows/misc-upstream-deb-mirror.yml
+++ b/.github/workflows/misc-upstream-deb-mirror.yml
@@ -132,6 +132,7 @@ jobs:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
       - name: Upload .deb to PackageCloud
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: pi-top/ghaction-packagecloud@main
         with:
           repository: ${{ env.PACKAGECLOUD_REPO }}/${{ env.OS }}/${{ env.DISTRO }}

--- a/.github/workflows/pypi-deb-build.yml
+++ b/.github/workflows/pypi-deb-build.yml
@@ -49,32 +49,25 @@ jobs:
           
         include:
           - docker_architecture: "amd64"
-            package:
-              - ["click-logging", "", ""]
+            package: ["click-logging", "", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["imutils", "", ""]
+            package: ["imutils", "", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["async-timeout", "", ""]
+            package: ["async-timeout", "", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["charset-normalizer", "", ""]
+            package: ["charset-normalizer", "", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["python-osc", "--package3 python3-osc", ""]
+            package: ["python-osc", "--package3 python3-osc", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["python-sonic", "--package3 python3-sonic --depends3 python3-osc", ""]
+            package: ["python-sonic", "--package3 python3-sonic --depends3 python3-osc", ""]
 
           - docker_architecture: "amd64"
-            package:
-              - ["aiosignal", "--depends3 'python3-frozenlist (>=1.1.0)'", ""]
+            package: ["aiosignal", "--depends3 'python3-frozenlist (>=1.1.0)'", ""]
 
     steps:
       - name: Checkout code
@@ -92,7 +85,7 @@ jobs:
             pitop/pypi-build:latest \
             bash -c "sudo apt update && \
             ./pypi-build/scripts/pypi-build.py ${{ matrix.package[0] }} \
-              --options-str=\"${{ matrix.package[3] }} --upstream-version-suffix '+ptos3' --debian-version ${{ github.run_number }}\" "
+              --options-str=\"${{ matrix.package[1] }} --upstream-version-suffix '+ptos3' --debian-version ${{ github.run_number }}\" "
 
       - name: Generate artifact name
         run: |

--- a/.github/workflows/pypi-deb-build.yml
+++ b/.github/workflows/pypi-deb-build.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload .deb to PackageCloud
         uses: pi-top/ghaction-packagecloud@main
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           repository: ${{ env.PACKAGECLOUD_REPO }}/${{ env.OS }}/${{ env.DISTRO }}
           files: |

--- a/.github/workflows/python3-onnxruntime-deb-build.yml
+++ b/.github/workflows/python3-onnxruntime-deb-build.yml
@@ -105,6 +105,7 @@ jobs:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
       - name: Upload .deb to PackageCloud
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: pi-top/ghaction-packagecloud@main
         with:
           repository: ${{ env.PACKAGECLOUD_REPO }}/${{ env.OS }}/${{ env.DISTRO }}


### PR DESCRIPTION
- Remove double array on `include` variables, which was causing the `amd64` packages not to build correctly.
- Access correct index from `matrix.package` on pypi-build's `--options-str`